### PR TITLE
Add support for swap_motor_direction setting

### DIFF
--- a/src/curtis.c
+++ b/src/curtis.c
@@ -6,6 +6,12 @@
 #include <string.h>
 #include <velib/vecan/products.h>
 
+static int swapMotorDirection = -1; // cache for Swap_Motor_Direction
+
+static void onSwapMotorDirectionResponse(CanOpenPendingSdoRequest *request) {
+    swapMotorDirection = request->response.data;
+}
+
 static void onBatteryVoltageResponse(CanOpenPendingSdoRequest *request) {
     VeVariant v;
     Device *device;
@@ -44,6 +50,9 @@ static void onMotorRpmResponse(CanOpenPendingSdoRequest *request) {
 
     device = (Device *)request->context;
     rpm = request->response.data;
+    if (swapMotorDirection == 1) { // Throttle is reversed
+        rpm *= -1;
+    }
 
     veItemOwnerSet(device->motorRpm, veVariantUn16(&v, abs(rpm)));
 
@@ -75,7 +84,7 @@ static void onMotorTorqueResponse(CanOpenPendingSdoRequest *request) {
 
     memcpy(&torque, &request->response.data, sizeof(torque));
 
-    veItemOwnerSet(device->motorTorque, veVariantFloat(&v, torque));
+    veItemOwnerSet(device->motorTorque, veVariantFloat(&v, fabsf(torque)));
 }
 
 static void onControllerTemperatureResponse(CanOpenPendingSdoRequest *request) {
@@ -94,6 +103,10 @@ static void onError(CanOpenPendingSdoRequest *request) {
 }
 
 static void readRoutine(Device *device) {
+    if (swapMotorDirection == -1) {
+        canOpenReadSdoAsync(device->nodeId, 0x362F, 0, device,
+                            onSwapMotorDirectionResponse, onError);
+    }
     canOpenReadSdoAsync(device->nodeId, 0x34C1, 0, device,
                         onBatteryVoltageResponse, onError);
     canOpenReadSdoAsync(device->nodeId, 0x338F, 0, device,


### PR DESCRIPTION
If swap_motor_direction is set on the motor controller reverse the RPM.  Note that this is only read once on driver startup
This has been tested on Venus 3.62 /Cerbo using GUI V1

This also contains the fix for negative torque per the previous request