### PR TITLE
Explicitly set current response as signed

### DIFF
--- a/src/curtis.c
+++ b/src/curtis.c
@@ -6,6 +6,12 @@
 #include <string.h>
 #include <velib/vecan/products.h>
 
+static int swapMotorDirection = -1; // cache for Swap_Motor_Direction
+
+static void onSwapMotorDirectionResponse(CanOpenPendingSdoRequest *request) {
+    swapMotorDirection = request->response.data;
+}
+
 static void onBatteryVoltageResponse(CanOpenPendingSdoRequest *request) {
     VeVariant v;
     Device *device;
@@ -26,7 +32,7 @@ static void onBatteryCurrentResponse(CanOpenPendingSdoRequest *request) {
     float current;
 
     device = (Device *)request->context;
-    current = request->response.data * 0.1F;
+    current = ((sn32)request->response.data) * 0.1F;
 
     veItemOwnerSet(device->current, veVariantFloat(&v, current));
 
@@ -44,6 +50,9 @@ static void onMotorRpmResponse(CanOpenPendingSdoRequest *request) {
 
     device = (Device *)request->context;
     rpm = request->response.data;
+    if (swapMotorDirection == 1) { // Throttle is reversed
+        rpm *= -1;
+    }
 
     veItemOwnerSet(device->motorRpm, veVariantUn16(&v, abs(rpm)));
 
@@ -75,7 +84,7 @@ static void onMotorTorqueResponse(CanOpenPendingSdoRequest *request) {
 
     memcpy(&torque, &request->response.data, sizeof(torque));
 
-    veItemOwnerSet(device->motorTorque, veVariantFloat(&v, torque));
+    veItemOwnerSet(device->motorTorque, veVariantFloat(&v, fabsf(torque)));
 }
 
 static void onControllerTemperatureResponse(CanOpenPendingSdoRequest *request) {
@@ -94,6 +103,10 @@ static void onError(CanOpenPendingSdoRequest *request) {
 }
 
 static void readRoutine(Device *device) {
+    if (swapMotorDirection == -1) {
+        canOpenReadSdoAsync(device->nodeId, 0x362F, 0, device,
+                            onSwapMotorDirectionResponse, onError);
+    }
     canOpenReadSdoAsync(device->nodeId, 0x34C1, 0, device,
                         onBatteryVoltageResponse, onError);
     canOpenReadSdoAsync(device->nodeId, 0x338F, 0, device,


### PR DESCRIPTION
For some reason, the curtis controller usually reports a current of -1 when in idle.  Without this fix, this ends up showing a power consumption of 30GW or so....

This also contains the previous two patches